### PR TITLE
Clarify optional Arduino serial support

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,9 +37,21 @@ A Processing + Arduino sketch that doubles as a workshop kit on community consen
 - **Buttons (top bar):** Consent, Avatar, REC, Show my image, Delete now
 - **Keys:** `s` (save→review), `y/n` (confirm/discard), `v` (REC), `c` (consent),
   `m` (mirror), `d` (debug), `f` (feather), `g` (gate writes on face), `t` (auto REC on face),
-  `A` (avatar), `N` (new avatar), `o` (show last), `Delete` (delete last)
+ `A` (avatar), `N` (new avatar), `o` (show last), `Delete` (delete last)
 - **Arduino serial:** `SAVE` (first tap), `SAVE_DBL` (second tap ≤1s), `REC` (toggle),
   `CONSENT_TOGGLE` (long-press ≥1.5s)
+
+### No Arduino? No problem.
+
+Running this on a laptop with zero hardware attached is totally valid. The console will drop a
+message that reads:
+
+```
+No serial ports found — keyboard/mouse controls stay live. Plug in the workshop Arduino and restart when ready.
+```
+
+That’s just the sketch letting you know it didn’t detect the optional button board. You can hammer on
+the on-screen UI or the keyboard shortcuts and every feature still works.
 
 ## Folder structure
 

--- a/processing/FaceSlugPrivacyTeaching.pde
+++ b/processing/FaceSlugPrivacyTeaching.pde
@@ -528,7 +528,10 @@ void deleteLastSaved() {
 // ------------------------------
 void setupSerial() {
   String[] ports = Serial.list();
-  if (ports == null || ports.length == 0) { println("No serial ports found."); return; }
+  if (ports == null || ports.length == 0) {
+    println("No serial ports found — keyboard/mouse controls stay live. Plug in the workshop Arduino and restart when ready.");
+    return;
+  }
   println("Serial ports:");
   for (int i=0;i<ports.length;i++) println("  ["+i+"] "+ports[i]);
 


### PR DESCRIPTION
## Summary
- soften the serial setup logging so running without the workshop Arduino is framed as intentional
- document the no-hardware path in the README so facilitators know the sketch still works keyboard-only

## Testing
- not run (Processing sketch, no automated test harness available)


------
https://chatgpt.com/codex/tasks/task_e_68cc61c327e0832588f3ddb0857c8f1c