### PR TITLE
Prefer USB VIDEO DEVICE camera

### DIFF
--- a/processing/FaceSlugPrivacyTeaching.pde
+++ b/processing/FaceSlugPrivacyTeaching.pde
@@ -1010,6 +1010,14 @@ PImage makeRadialFeatherMask(int w, int h, float innerRadius, float featherPx) {
 
 String pickCamera() {
   String[] cams = Capture.list(); if (cams == null || cams.length == 0) return null;
+
+  String preferredName = "usb video device";
+  for (String c : cams) {
+    if (c.toLowerCase().contains(preferredName)) {
+      return c;
+    }
+  }
+
   for (String c : cams) if (c.toLowerCase().contains("1280x720"))  return c;
   for (String c : cams) if (c.toLowerCase().contains("1920x1080")) return c;
   return cams[0];


### PR DESCRIPTION
## Summary
- update the camera selection helper so it first looks for a device whose name contains "USB VIDEO DEVICE"
- keep the existing resolution-based fallbacks if that device is not present

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cc69b3805c83259c44031b87fcd353