### PR TITLE
Annotate workshop sketches with exhaustive commentary

### DIFF
--- a/arduino/SaveRecDoubleLongPress/SaveRecDoubleLongPress.ino
+++ b/arduino/SaveRecDoubleLongPress/SaveRecDoubleLongPress.ino
@@ -1,37 +1,46 @@
 // Arduino: SAVE button with short/double/long; REC toggle.
-// Wire each button between pin and GND (INPUT_PULLUP).
+// -----------------------------------------------------------------------------
+// This sketch is the hardware wing of the Face → Slug teaching rig. We speak a
+// micro-serial language that mirrors the Processing sketch:
+//   - quick tap  → "SAVE" (stage capture in RAM)
+//   - double tap → "SAVE_DBL" (auto-save if consent is already ON)
+//   - long hold  → "CONSENT_TOGGLE" (flip consent state without capturing)
+//   - REC button → "REC" (Processing will start/stop the MP4 session)
+// Buttons are wired between the pin and GND while using INPUT_PULLUP so idle = HIGH.
 
 const int BTN_SAVE = 2;  // short: SAVE, double (≤1s): SAVE_DBL, long (≥1.5s): CONSENT_TOGGLE
 const int BTN_REC  = 3;  // REC toggle
 
-const unsigned long DOUBLE_MS = 1000;   // double-press window (single fires after this expires)
-const unsigned long LONG_MS   = 1500;   // long-press threshold
+// Gesture timing windows (in milliseconds)
+const unsigned long DOUBLE_MS = 1000;   // allow 1 second for the second tap
+const unsigned long LONG_MS   = 1500;   // long-press threshold for consent toggle
 
-// SAVE button FSM
-bool saveDown = false;
-unsigned long saveDownAt = 0;
+// SAVE button finite-state machine bookkeeping
+bool saveDown = false;            // is the SAVE button currently pressed?
+unsigned long saveDownAt = 0;     // when the press started
 
-// Short press gets queued until the double-tap window expires.
-unsigned long pendingStartedAt = 0;
-bool pendingSingle = false;
+// Short presses queue up in case they grow into a double-tap.
+unsigned long pendingStartedAt = 0; // when we started waiting for the second tap
+bool pendingSingle = false;          // true while we’re waiting to resolve single vs double
 
+// Guard so long-press doesn’t emit SAVE events on release.
 bool longFired = false;
 
 void setup() {
   pinMode(BTN_SAVE, INPUT_PULLUP);
   pinMode(BTN_REC,  INPUT_PULLUP);
-  Serial.begin(115200);
+  Serial.begin(115200); // matches the Processing sketch’s SERIAL_BAUD
 }
 
 void loop() {
-  static bool prevSave = HIGH, prevRec = HIGH;
+  static bool prevSave = HIGH, prevRec = HIGH; // previous sample for edge detection
   bool curSave = digitalRead(BTN_SAVE);
   bool curRec  = digitalRead(BTN_REC);
   unsigned long now = millis();
 
   // --- SAVE button state machine ---
   if (prevSave == HIGH && curSave == LOW) {
-    // press
+    // button just went down
     saveDown = true;
     longFired = false;
     saveDownAt = now;
@@ -43,19 +52,21 @@ void loop() {
       // Long-press: CONSENT_TOGGLE, consume gesture (no SAVE messages)
       Serial.println("CONSENT_TOGGLE");
       longFired = true;
-      pendingSingle = false; // cancel pending single
+      pendingSingle = false; // cancel pending single so release stays quiet
     }
   }
 
   if (prevSave == LOW && curSave == HIGH) {
-    // release
+    // button just went up
     saveDown = false;
     if (!longFired) {
       if (pendingSingle && (now - pendingStartedAt) <= DOUBLE_MS) {
-        Serial.println("SAVE_DBL");    // explicit double
+        // second tap arrived in time → emit explicit double
+        Serial.println("SAVE_DBL");
         pendingSingle = false;
       } else {
-        pendingSingle = true;          // wait to see if a second tap arrives
+        // first tap: tentatively mark as single and wait for a partner
+        pendingSingle = true;
         pendingStartedAt = now;
       }
     }
@@ -73,7 +84,7 @@ void loop() {
     Serial.println("REC");
   }
 
-  // crude debounce
+  // crude debounce so bouncy buttons don’t double-trigger
   delay(8);
 
   prevSave = curSave;


### PR DESCRIPTION
## Summary
- expand configuration and state commentary throughout `FaceSlugPrivacyTeaching.pde` so facilitators can narrate every toggle and gate
- document every workflow phase in `ConsentDetect.pde`, covering lifecycle, consent handling, and retention sweeps
- turn the Arduino button sketch into a narrated state-machine guide that mirrors the Processing controls

## Testing
- not run (Processing / Arduino sketches)


------
https://chatgpt.com/codex/tasks/task_e_68cc9a6cca908325977955cb76018774