### PR TITLE
Improve macOS fallback pipeline stability

### DIFF
--- a/processing/FaceSlugPrivacyTeaching.pde
+++ b/processing/FaceSlugPrivacyTeaching.pde
@@ -588,10 +588,20 @@ String buildMacPipelineFallback() {
     if (looseMatch >= 0) index = looseMatch;
   }
 
+  int w = CAM_W > 0 ? CAM_W : 1280;
+  int h = CAM_H > 0 ? CAM_H : 720;
+  int fps = RECORD_FPS > 0 ? RECORD_FPS : 30;
+
+  String macCaps =
+    "video/x-raw,width=" + w +
+    ",height=" + h +
+    ",framerate=" + fps + "/1";
+
   String pipeline =
     "pipeline:avfvideosrc device-index=" + index +
-    " capturecaps=video/x-raw,format=NV12,width=" + CAM_W +
-    ",height=" + CAM_H + ",framerate=" + RECORD_FPS + "/1 ! videoconvert";
+    " ! " + macCaps +
+    " ! queue max-size-buffers=2 leaky=downstream" +
+    " ! videoconvert ! video/x-raw,format=RGB";
   return pipeline;
 }
 


### PR DESCRIPTION
## Summary
- tweak the macOS camera fallback pipeline to use a gentler avfvideosrc chain
- request width/height/fps caps directly and add a small queue plus RGB convert to avoid GStreamer stalls

## Testing
- not run (camera hardware unavailable in container)


------
https://chatgpt.com/codex/tasks/task_e_68cf38a0cf2c83259aa21617c6066cf1